### PR TITLE
Added:keep_array_duplicates option

### DIFF
--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -62,6 +62,12 @@ module DeepMerge
   #   dest   = {:x => [{:z => 2}]}
   #   dest.deep_merge!(source, {:merge_hash_arrays => true})
   #   Results: {:x => [{:y => 1, :z => 2}]}
+  #
+  # :keep_array_duplicates => merges arrays within hashes but keeps duplicate elements
+  #   source = {:x => {:y => [1,2,2,2,3]}}
+  #   dest   = {:x => {:y => [4,5,6]}}
+  #   dest.deep_merge!(source, {:keep_array_duplicates => true})
+  #   Results: {:x => {:y => [1,2,2,2,3,4,5,6]}}
   # 
   # There are many tests for this library - and you can learn more about the features
   # and usages of deep_merge! by just browsing the test examples
@@ -78,6 +84,8 @@ module DeepMerge
     sort_merged_arrays = options[:sort_merged_arrays] || false
     # request that arrays of hashes are merged together
     merge_hash_arrays = options[:merge_hash_arrays] || false
+    # request that arrays keep duplicate elements
+    keep_array_duplicates = options[:keep_array_duplicates] || false
     di = options[:debug_indent] || ''
     # do nothing if source is nil
     return dest if source.nil?
@@ -155,6 +163,8 @@ module DeepMerge
           end
           list += source[dest.count..-1] if source.count > dest.count
           dest = list
+        elsif keep_array_duplicates
+          dest = dest.concat(source)
         else
           dest = dest | source
         end


### PR DESCRIPTION
The keep_array_duplicates option retains duplicate array elements after a deep_merge.