### PR TITLE
tests: switch to minitest

### DIFF
--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
     "test/test_deep_merge.rb"
   ]
 
+  s.add_development_dependency "minitest"
   s.add_development_dependency "rake", "~> 10.1"
 
 end

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 
 $:.unshift(File.dirname(__FILE__) + '/../lib/')
 require 'deep_merge'
@@ -11,7 +11,7 @@ module StringBlank
   end
 end
 
-class TestDeepMerge < Test::Unit::TestCase
+class TestDeepMerge < Minitest::Test
 
   def setup
   end
@@ -214,12 +214,13 @@ class TestDeepMerge < Test::Unit::TestCase
     assert_equal({"property" => {"bedroom_count" => {"king_bed" => [nil, 3], "queen_bed" => [4, nil, 1]}, "bathroom_count" => [nil, "2", "1"]}}, hash_dst)
 
     # test parameter management for knockout_prefix and overwrite unmergable
-    assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => ""})}
-    assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true, :knockout_prefix => ""})}
-    assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true, :knockout_prefix => "--"})}
-    assert_nothing_raised(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => "--"})}
-    assert_nothing_raised(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst)}
-    assert_nothing_raised(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true})}
+    assert_raises(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => ""})}
+    assert_raises(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true, :knockout_prefix => ""})}
+    assert_raises(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true, :knockout_prefix => "--"})}
+    # test valid parameters
+    DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => "--"})
+    DeepMerge::deep_merge!(hash_src, hash_dst)
+    DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true})
 
     # hash holding arrays of arrays
     hash_src = {["1", "2", "3"] => ["1", "2"]}


### PR DESCRIPTION
Ruby 1.9+ uses Minitest as the backend for Test::Unit. As of Minitest 5, the shim has broken some compatibility with Test::Unit::TestCase in some scenarios.

This pull request adjusts the test suite to support Minitest 5's syntax.