### PR TITLE
include LICENSE file in gem

### DIFF
--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email = %q{dan@kallistec.com}
   s.license = 'MIT'
   s.extra_rdoc_files = [
+    "LICENSE",
     "README.md"
   ]
   s.files = [


### PR DESCRIPTION
This pull request adds the LICENSE file to the gemspec so that gem downloads (eg from rubygems.org) will contain the full license text.

By including a copy of the exact MIT license text in the deep_merge gem, we make the terms of the license very clear.

Also, in the specific case of deep_merge's MIT license, all derivative copies of deep_merge are required to contain the disclaimer text within the MIT license (as described in the sentence "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.") So in order to ease development and distribution of deep_merge, it makes sense to simply include this text in the gem.