### PR TITLE
use HTTPS URL in gemspec

### DIFF
--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "lib/deep_merge/rails_compat.rb",
     "test/test_deep_merge.rb"
   ]
-  s.homepage = %q{http://github.com/danielsdeleo/deep_merge}
+  s.homepage = %q{https://github.com/danielsdeleo/deep_merge}
   s.require_paths = ["lib"]
   s.summary = %q{Merge Deeply Nested Hashes}
   s.test_files = [


### PR DESCRIPTION
This pull request updates the deep_merge gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.