### PR TITLE
Added option to extend existing arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Options are specified in the last parameter passed, which should be in hash form
       Set to string value to run "Array::join" then "String::split" against all arrays
     :merge_hash_arrays      DEFAULT: false
       Set to true to merge hashes within arrays
+    :extend_existing_arrays DEFAULT: false
+      Set to true to extend existing arrays, instead of overwriting them
     :merge_debug            DEFAULT: false
       Set to true to get console output of merge process for debugging
 
@@ -76,6 +78,15 @@ merge hashes within arrays
     dest   = {:x => [{:z => 2}]}
     dest.deep_merge!(source, {:merge_hash_arrays => true})
     Results: {:x => [{:y => 1, :z => 2}]}
+
+**:extend_existing_arrays**
+
+Push src elements to existing arrays, instead of overwriting them.
+
+    source = { "property" => "4" }
+    dest   = { "property" => ["1", "2", "3"] }
+    dest.deep_merge!(source, {:extend_existing_arrays => true})
+    Results: {"property" => ["1", "2", "3", "4"]}
 
 There are many tests for this library - and you can learn more about the features and usages of deep_merge! by just browsing the test examples.
 

--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -78,6 +78,9 @@ module DeepMerge
     sort_merged_arrays = options[:sort_merged_arrays] || false
     # request that arrays of hashes are merged together
     merge_hash_arrays = options[:merge_hash_arrays] || false
+    # request to extend existing arrays, instead of overwriting them
+    extend_existing_arrays = options[:extend_existing_arrays] || false
+
     di = options[:debug_indent] || ''
     # do nothing if source is nil
     return dest if source.nil?
@@ -164,8 +167,12 @@ module DeepMerge
         dest = overwrite_unmergeables(source, dest, options)
       end
     else # src_hash is not an array or hash, so we'll have to overwrite dest
-      puts "#{di}Others: #{source.inspect} :: #{dest.inspect}" if merge_debug
-      dest = overwrite_unmergeables(source, dest, options)
+      if dest.kind_of?(Array) && extend_existing_arrays
+        dest.push(source)
+      else
+        puts "#{di}Others: #{source.inspect} :: #{dest.inspect}" if merge_debug
+        dest = overwrite_unmergeables(source, dest, options)
+      end
     end
     puts "#{di}Returning #{dest.inspect}" if merge_debug
     dest

--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -108,6 +108,8 @@ module DeepMerge
             end
             dest[src_key] = deep_merge!(src_value, src_dup, options.merge(:debug_indent => di + '  '))
           end
+        elsif dest.kind_of?(Array) && extend_existing_arrays
+          dest.push(source)
         else # dest isn't a hash, so we overwrite it completely (if permitted)
           if overwrite_unmergeable
             puts "#{di}  overwriting dest: #{src_key.inspect} => #{src_value.inspect} -over->  #{dest.inspect}" if merge_debug

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -216,7 +216,7 @@ class TestDeepMerge < Test::Unit::TestCase
     # if destination element is an array and source element is not, push source element to destination array
     hash_src = { "property" => "4" }
     hash_dst = { "property" => ["1", "2", "3"] }
-    DeepMerge::deep_merge!(hash_src, hash_dst, extend_existing_arrays: true)
+    DeepMerge::deep_merge!(hash_src, hash_dst, :extend_existing_arrays => true)
     assert_equal({"property" => ["1", "2", "3", "4"]}, hash_dst)
 
     # test parameter management for knockout_prefix and overwrite unmergable

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -213,6 +213,12 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst)
     assert_equal({"property" => {"bedroom_count" => {"king_bed" => [nil, 3], "queen_bed" => [4, nil, 1]}, "bathroom_count" => [nil, "2", "1"]}}, hash_dst)
 
+    # if destination element is an array and source element is not, push source element to destination array
+    hash_src = { "property" => "4" }
+    hash_dst = { "property" => ["1", "2", "3"] }
+    DeepMerge::deep_merge!(hash_src, hash_dst, extend_existing_arrays: true)
+    assert_equal({"property" => ["1", "2", "3", "4"]}, hash_dst)
+
     # test parameter management for knockout_prefix and overwrite unmergable
     assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => ""})}
     assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true, :knockout_prefix => ""})}

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -213,11 +213,17 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst)
     assert_equal({"property" => {"bedroom_count" => {"king_bed" => [nil, 3], "queen_bed" => [4, nil, 1]}, "bathroom_count" => [nil, "2", "1"]}}, hash_dst)
 
-    # if destination element is an array and source element is not, push source element to destination array
+    # if extend_existig_arrays == true && destination.kind_of?(Array) && source element is neither array nor hash, push source to destionation
     hash_src = { "property" => "4" }
     hash_dst = { "property" => ["1", "2", "3"] }
     DeepMerge::deep_merge!(hash_src, hash_dst, :extend_existing_arrays => true)
     assert_equal({"property" => ["1", "2", "3", "4"]}, hash_dst)
+
+    # if extend_existig_arrays == true && destination.kind_of?(Array) && source.kind_of(Hash), push source to destionation
+    hash_src = { "property" => {:number => "3"} }
+    hash_dst = { "property" => [{:number => "1"}, {:number => "2"}] }
+    DeepMerge::deep_merge!(hash_src, hash_dst, :extend_existing_arrays => true)
+    assert_equal({"property"=>[{:number=>"1"}, {:number=>"2"}, {:number=>"3"}]}, hash_dst)
 
     # test parameter management for knockout_prefix and overwrite unmergable
     assert_raise(DeepMerge::InvalidParameter) {DeepMerge::deep_merge!(hash_src, hash_dst, {:knockout_prefix => ""})}


### PR DESCRIPTION
Hi !

I added an option to extend existing arrays. Example

```ruby
source = { "property" => "4" }
dest   = { "property" => ["1", "2", "3"] }
dest.deep_merge!(source, {:extend_existing_arrays => true})
Results: {"property" => ["1", "2", "3", "4"]}
```

There is a test and I added docs to the README. Hope you find this useful. Personally, I need this very often.

Cheers