### PR TITLE
Skip merging if the destination is nil

### DIFF
--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -92,9 +92,13 @@ module DeepMerge
       source.each do |src_key, src_value|
         if dest.kind_of?(Hash)
           puts "#{di} looping: #{src_key.inspect} => #{src_value.inspect} :: #{dest.inspect}" if merge_debug
-          if dest[src_key]
-            puts "#{di} ==>merging: #{src_key.inspect} => #{src_value.inspect} :: #{dest[src_key].inspect}" if merge_debug
-            dest[src_key] = deep_merge!(src_value, dest[src_key], options.merge(:debug_indent => di + '  '))
+          if dest.has_key?(src_key)
+            if dest[src_key].nil?
+              puts "#{di} ==>skipping: #{src_key.inspect} => #{src_value.inspect} :: #{dest[src_key].inspect}" if merge_debug
+            else
+              puts "#{di} ==>merging: #{src_key.inspect} => #{src_value.inspect} :: #{dest[src_key].inspect}" if merge_debug
+              dest[src_key] = deep_merge!(src_value, dest[src_key], options.merge(:debug_indent => di + '  '))
+            end
           else # dest[src_key] doesn't exist so we want to create and overwrite it (but we do this via deep_merge!)
             puts "#{di} ==>merging over: #{src_key.inspect} => #{src_value.inspect}" if merge_debug
             # note: we rescue here b/c some classes respond to "dup" but don't implement it (Numeric, TrueClass, FalseClass, NilClass among maybe others)


### PR DESCRIPTION
I think we should not overwrite value if you purposely set nil.

e.g.

Consider merging `{ foo: { bar: 1 } }` and `{ foo: { bar: nil } }`.

It should merge them `{ foo: { bar: nil } }` instead of `{ foo: { bar: 1 } }` because `nil` is set purposely.
If you want to have `{ bar: 1 }`, we can merge `{ foo: {} }`.

What do you think?
