### PR TITLE
Add overwrite_arrays option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Options are specified in the last parameter passed, which should be in hash form
       Set to true to skip any unmergeable elements from source
     :knockout_prefix        DEFAULT: nil
       Set to string value to signify prefix which deletes elements from existing element
+    :overwrite_arrays       DEFAULT: false
+      Set to true if you want to avoid merging arrays
     :sort_merged_arrays     DEFAULT: false
       Set to true to sort all arrays that are merged together
     :unpack_arrays          DEFAULT: nil
@@ -56,6 +58,15 @@ Additionally, if the knockout_prefix is passed alone as a string, it will cause 
     dest   = {:x => [1,2,3]}
     dest.ko_deep_merge!(source)
     Results: {:x => ""}
+
+**:overwrite_arrays**
+
+The purpose of this is to provide a way to replace Arrays instead of having them merge together.
+
+    source = {:x => ['1', '2']}
+    dest   = {:x => ['3', '4']}
+    dest.deep_merge!(source, {:overwrite_arrays => true})
+    Results: {:x => ['1', '2']}
 
 **:unpack_arrays**
 

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -87,6 +87,12 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst)
     assert_equal(["2","4","1","3"], hash_dst['property'])
 
+    # hashes holding array (overwrite)
+    hash_src = {"property" => ["1","3"]}
+    hash_dst = {"property" => ["2","4"]}
+    DeepMerge::deep_merge!(hash_src, hash_dst, {:overwrite_arrays => true})
+    assert_equal(["1","3"], hash_dst['property'])
+
     # hashes holding array (sorted)
     hash_src = {"property" => ["1","3"]}
     hash_dst = {"property" => ["2","4"]}


### PR DESCRIPTION
This is an extraction from
https://github.com/railsconfig/config/pull/103 where @dtaniwaki had
added this option, but had done it prior to the deep_merge extraction.

Paired with @carbonin <https://github.com/carbonin> on this.