### PR TITLE
False values should not be considered unmergeable

### DIFF
--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -222,7 +222,7 @@ module DeepMerge
         puts "#{di}\"\" -over-> #{dest.inspect}" if merge_debug
         dest = ""
       end
-    elsif overwrite_unmergeable
+    elsif overwrite_unmergeable || source.kind_of?(FalseClass)
       dest = source
     end
     dest

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -87,6 +87,18 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst)
     assert_equal(["2","4","1","3"], hash_dst['property'])
 
+    # take false value from source
+    hash_src = {"name" => false}
+    hash_dst = {"name" => true}
+    DeepMerge::deep_merge!(hash_src, hash_dst)
+    assert_equal({"name" => false}, hash_dst)
+
+    # take false value from source even when preserving unmergables
+    hash_src = {"name" => false}
+    hash_dst = {"name" => true}
+    DeepMerge::deep_merge!(hash_src, hash_dst, {:preserve_unmergeables => true})
+    assert_equal({"name" => false}, hash_dst)
+
     # hashes holding array (overwrite)
     hash_src = {"property" => ["1","3"]}
     hash_dst = {"property" => ["2","4"]}


### PR DESCRIPTION
Unless I've misunderstood, merging `{"name" => false}` into `{"name" => true}` should  
result in `{"name" => false}` even if `preserve_mergeables` is enabled.
Perhaps this change should be behind another setting, to maintain backwards compatibility.