### PR TITLE
Fix for scenario when destination is false

### DIFF
--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -111,7 +111,7 @@ module DeepMerge
       source.each do |src_key, src_value|
         if dest.kind_of?(Hash)
           puts "#{di} looping: #{src_key.inspect} => #{src_value.inspect} :: #{dest.inspect}" if merge_debug
-          if dest[src_key]
+          if dest.key?(src_key)
             puts "#{di} ==>merging: #{src_key.inspect} => #{src_value.inspect} :: #{dest[src_key].inspect}" if merge_debug
             dest[src_key] = deep_merge!(src_value, dest[src_key], options.merge(:debug_indent => di + '  '))
           else # dest[src_key] doesn't exist so we want to create and overwrite it (but we do this via deep_merge!)

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -99,6 +99,12 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst, {:sort_merged_arrays => true})
     assert_equal(["1","2","3","4"].sort, hash_dst['property'])
 
+    # hashes with a false value; do not overwrite keys (like having a defaults hash and a user-defined hash)
+    hash_src  = {"name" => true,  "name1" => "value1"}
+    hash_dst  = {"name" => false, "name1" => "value"}
+    DeepMerge::deep_merge!(hash_src, hash_dst, preserve_unmergeables: true)
+    assert_equal({"name" => false, "name1" => "value"}, hash_dst)
+
     # hashes holding hashes holding arrays (array with duplicate elements is merged with dest then src
     hash_src = {"property" => {"bedroom_count" => ["1", "2"], "bathroom_count" => ["1", "4+"]}}
     hash_dst = {"property" => {"bedroom_count" => ["3", "2"], "bathroom_count" => ["2"]}}


### PR DESCRIPTION
The previous check would evaluate to `false` if the value is `false`. We should instead check if the key exists, and not check truthiness.