### PR TITLE
Fixes #32 duplicated arrays on nil merge, adds test case

### DIFF
--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -122,6 +122,11 @@ module DeepMerge
             rescue TypeError
               src_dup = src_value
             end
+            if src_dup.kind_of?(Array) && keep_array_duplicates
+              # note: in this case the merge will be additive, rather than a bounded set, so we can't simply merge src with itself
+              # We need to merge src with an empty array
+              src_dup = []
+            end
             dest[src_key] = deep_merge!(src_value, src_dup, options.merge(:debug_indent => di + '  '))
           end
         elsif dest.kind_of?(Array) && extend_existing_arrays

--- a/test/test_deep_merge.rb
+++ b/test/test_deep_merge.rb
@@ -630,6 +630,12 @@ class TestDeepMerge < Test::Unit::TestCase
     DeepMerge::deep_merge!(hash_src, hash_dst, {:keep_array_duplicates => true})
     assert_equal({"item" => ["1", "2", "2", "3"]}, hash_dst)
 
+    # For Issue 34 - keep_array_duplicates against a nil src doesn't do a recursive merge
+    hash_src = {"item" => ["2", "3"]}
+    hash_dst = { }
+    DeepMerge::deep_merge!(hash_src, hash_dst, {:keep_array_duplicates => true})
+    assert_equal({"item" => ["2", "3"]}, hash_dst)
+
     # Don't merge nil values by default
     hash_src = {"item" => nil}
     hash_dst = {"item" => "existing"}


### PR DESCRIPTION
Fixes #32 - passes the test cases OK

While I assume this lib is bug compatible - its .... pretty wrong behaviour. I suppose it could be made opt-in but I can't see where the dupe behaviour would ever be the expected outcome. 