### PR TITLE
update rake to be able to run tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,21 +8,18 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.0'
-        - '2.1'
-        - '2.2'
-        - '2.3'
-        - '2.4'
-        - '2.5'
-        - '2.6'
         - '2.7'
         - '3.0'
-        allow-failure: [false]
+        - '3.1'
+        - '3.2'
+        - '3.3'
+        continue-on-error: [false]
         include:
         - ruby-version: ruby-head
-          allow-failure: true
+          continue-on-error: true
         - ruby-version: jruby-head
-          allow-failure: true
+          continue-on-error: true
+    name: ruby ${{ matrix.ruby-version }} rake
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -32,4 +29,4 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
-      continue-on-error: ${{ matrix.allow-failure }}
+      continue-on-error: ${{ matrix.continue-on-error }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+  * Dropped support for ruby versions before 2.7
+
 2022-01-07 Jason Frey <fryguy9@gmail.com>
   * Ship version 1.2.2
 

--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
   s.test_files = [
     "test/test_deep_merge.rb"
   ]
+  s.required_ruby_version = '>= 2.7'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit-minitest"
-
 end

--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |s|
     "test/test_deep_merge.rb"
   ]
 
-  s.add_development_dependency "rake", "~> 10.1"
+  s.add_development_dependency "rake"
   s.add_development_dependency "test-unit-minitest"
 
 end
-


### PR DESCRIPTION
```
rake
rake aborted!
NoMethodError: undefined method `=~' for #<Proc:0x00000001001f7e48 rake-10.5.0/lib/rake/application.rb:393 (lambda)>
bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `load'
bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `kernel_load'
bundler-2.5.10/lib/bundler/cli/exec.rb:23:in `run'
```

cc @Fryguy 