### PR TITLE
Refactor gemspec

### DIFF
--- a/deep_merge.gemspec
+++ b/deep_merge.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 Gem::Specification.new do |s|
   s.name = %q{deep_merge}
   s.version = "1.2.2"
@@ -29,7 +27,7 @@ Gem::Specification.new do |s|
   s.test_files = [
     "test/test_deep_merge.rb"
   ]
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit-minitest"


### PR DESCRIPTION
## What's changed

- Remove `encoding: utf-8` comment in deep_merge.gemspec
- Fix `required_ruby_version` in deep_merge.gemspec

![rubygems_org](https://github.com/user-attachments/assets/e5228b87-35f5-4a7c-b0c2-af6e04f05ad1)

Currently, on rubygems.org, `REQUIRED RUBY VERSION` is displayed as `>= 0`.
